### PR TITLE
Fixed user group mapping with case-insensitive logins.

### DIFF
--- a/lib/Foswiki/Users/LdapUserMapping.pm
+++ b/lib/Foswiki/Users/LdapUserMapping.pm
@@ -556,7 +556,7 @@ sub login2cUID {
   my $loginName = $this->{ldap}->getLoginOfWikiName($name);
   $name = $loginName if defined $loginName;    # called with a wikiname
 
-  #$name = lc($name) unless $this->{ldap}{caseSensitiveLogin};
+  $name = lc($name) unless $this->{ldap}{caseSensitiveLogin};
   my $cUID = $this->{mapping_id} . Foswiki::Users::mapLogin2cUID($name);
 
   # don't ask topic user mapping for large wikis


### PR DESCRIPTION
When using LDAP for group assignments and making the login case-insensitive, the plugin will not correctly decide group assignments if the login capitilization differs from the WikiName version of the login. For example, in the following case:

```
dn: cn=Information_Technology,ou=group,dc=example,dc=com
cn: Information_Technology
objectClass: groupOfNames
member: cn=JackOfMostTrades,ou=person,dc=example,dc=com

dn: cn=JackOfMostTrades,ou=person,dc=example,dc=com
cn: JackOfMostTrades
objectClass: customPerson
objectClass: top
```

```
$Foswiki::cfg{Ldap}{LoginAttribute} = 'cn';
$Foswiki::cfg{Ldap}{WikiNameAttributes} = 'cn';
$Foswiki::cfg{Ldap}{NormalizeWikiNames} = 0;
$Foswiki::cfg{Ldap}{NormalizeLoginNames} = 0;
$Foswiki::cfg{Ldap}{CaseSensitiveLogin} = 0;
$Foswiki::cfg{Ldap}{AllowChangePassword} = 0;
$Foswiki::cfg{Ldap}{SecondaryPasswordManager} = '';
$Foswiki::cfg{Ldap}{UserMappingTopic} = '';
$Foswiki::cfg{Ldap}{GroupFilter} = 'objectClass=groupOfNames';
$Foswiki::cfg{Ldap}{GroupScope} = 'sub';
$Foswiki::cfg{Ldap}{GroupAttribute} = 'cn';
$Foswiki::cfg{Ldap}{PrimaryGroupAttribute} = '';
$Foswiki::cfg{Ldap}{MemberAttribute} = 'member';
$Foswiki::cfg{Ldap}{InnerGroupAttribute} = '';
$Foswiki::cfg{Ldap}{MemberIndirection} = 1;
$Foswiki::cfg{Ldap}{WikiGroupsBackoff} = 0;
$Foswiki::cfg{Ldap}{NormalizeGroupNames} = 0;
$Foswiki::cfg{Ldap}{MapGroups} = 1;
```

If I log in as either "JackOfMostTrades" or "jackofmosttrades", the plugin will correctly treat me as a member of the Information_Technology group (specifically for the purposes of access control). But if I login as "JackofMostTrades", the login2cUID() method returns "JackofMostTrades" and therefore does not discover my membership in the group (which has "jackofmosttrades" in its list).

The line appears to have been originally commented out during the implementation of the user-topic mapping feature, though it's unclear to me if there is a specific need for it in that context therefore warranting a more sophisticated fix.
