### PR TITLE
reentrant bug using each

### DIFF
--- a/lib/Foswiki/Contrib/LdapContrib.pm
+++ b/lib/Foswiki/Contrib/LdapContrib.pm
@@ -1676,7 +1676,16 @@ sub rewriteName {
 
   my $out = $in;
 
-  while (my ($pattern,$subst) = each %$rules) {
+  # for some reasons this loop only provided values 
+  # on every second call to rewriteName
+  # centos 7, perl 5.16.3
+  #
+  # might be re-entrant issue of each
+  # http://blogs.perl.org/users/rurban/2014/04/do-not-use-each.html
+  #
+  # while (my ($pattern,$subst) = each %$rules) {
+  for my $pattern (keys %$rules) {
+    my $subst = $rules{$pattern};
     if ($out =~ /^(?:$pattern)$/) {
       my $arg1 = $1;
       my $arg2 = $2;

--- a/lib/Foswiki/Contrib/LdapContrib.pm
+++ b/lib/Foswiki/Contrib/LdapContrib.pm
@@ -1695,7 +1695,7 @@ sub rewriteName {
   # avoids re-entrant bug of each
 
   for my $pattern (keys %$rules) {
-    my $subst = $rules{$pattern};
+    my $subst = $rules->{$pattern};
     if ($out =~ /^(?:$pattern)$/) {
       my $arg1 = $1;
       my $arg2 = $2;

--- a/lib/Foswiki/Contrib/LdapContrib.pm
+++ b/lib/Foswiki/Contrib/LdapContrib.pm
@@ -1676,14 +1676,24 @@ sub rewriteName {
 
   my $out = $in;
 
-  # for some reasons this loop only provided values 
-  # on every second call to rewriteName
-  # centos 7, perl 5.16.3
+  # Original:
+  # while (my ($pattern,$subst) = each %$rules) {
   #
-  # might be re-entrant issue of each
+  # this produces a re-entrant bug. 
   # http://blogs.perl.org/users/rurban/2014/04/do-not-use-each.html
   #
-  # while (my ($pattern,$subst) = each %$rules) {
+  # 1) something needs to be rewritten
+  # 2) start with the first entry in rules
+  # 3) it matches. rewrite it, return out (call to last)
+  # 4) something else needs to be rewritten
+  # 5) continue with the second entry in rules, as 
+  #    rules points to the same hash and each just
+  #    continues where it was. 
+  #    (re-entrant bug)
+  #
+  # use keys to fetch all keys and then iterate. 
+  # avoids re-entrant bug of each
+
   for my $pattern (keys %$rules) {
     my $subst = $rules{$pattern};
     if ($out =~ /^(?:$pattern)$/) {


### PR DESCRIPTION
looping with each over a hash is not reentrant save. As a result RewriteGroup and RewriteWikinames does not work.

using a {Ldap}{RewriteGroups} with one entry, which matches every group, for example adding a prefix:

``` perl
{
  '(.*)' => 'LDAP$1Group'
}
```

only every second group is rewritten.

the function rewriteName uses each, to iterate over RewriteGroups. For the first group it will rewrite and then jump out of the function (last). On the second call to rewriteNames it will continue where it left, finds no more pattern (end of while loop) and makes no rewrite. Third call then starts again at the top and rewrites.
