### PR TITLE
Fix issue with converting some group names and characters

### DIFF
--- a/lib/Foswiki/Contrib/LdapContrib.pm
+++ b/lib/Foswiki/Contrib/LdapContrib.pm
@@ -281,7 +281,7 @@ sub new {
     unless defined $this->{normalizeWikiName};
   $this->{normalizeLoginName} = $Foswiki::cfg{Ldap}{NormalizeLoginName}
     unless defined $this->{normalizeLoginName};
-  $this->{normalizeGroupName} = $Foswiki::cfg{Ldap}{NormalizeGroupName}
+  $this->{normalizeGroupName} = $Foswiki::cfg{Ldap}{NormalizeGroupNames}
     unless defined $this->{normalizeGroupName};
 
   @{$this->{wikiNameAttributes}} = split(/\s*,\s*/, $this->{wikiNameAttribute});
@@ -1512,6 +1512,7 @@ sub cacheGroupFromEntry {
     return 0;
   }
   $groupName =~ s/^\s+|\s+$//g;
+  $groupName = fromLdapCharSet($groupName);
 
   if ($this->{normalizeGroupName}) {
     $groupName = $this->normalizeWikiName($groupName);


### PR DESCRIPTION
Seems to be a typo and an added fromLdapCharSet to allow groups to properly convert from some Active Directory instances